### PR TITLE
Update BlueJ to 5.1.0

### DIFF
--- a/org.bluej.BlueJ.appdata.xml
+++ b/org.bluej.BlueJ.appdata.xml
@@ -33,6 +33,7 @@
     <kudo>HiDpiIcon</kudo>
   </kudos>
   <releases>
+    <release date="2022-09-20" version="5.1.0"/>
     <release date="2022-03-28" version="5.0.3"/>
     <release date="2021-08-06" version="5.0.2"/>
     <release date="2021-04-30" version="5.0.1"/>

--- a/org.bluej.BlueJ.desktop
+++ b/org.bluej.BlueJ.desktop
@@ -1,6 +1,7 @@
 [Desktop Entry]
 Name=BlueJ
+Comment=Java IDE for beginners
 Exec=org.bluej.BlueJ
 Type=Application
 Icon=org.bluej.BlueJ
-Categories=Development;Education;
+Categories=Development;Java;Education;

--- a/org.bluej.BlueJ.json
+++ b/org.bluej.BlueJ.json
@@ -45,9 +45,9 @@
       ],
       "sources": [{
         "type": "archive",
-        "url": "http://www.bluej.org/download/files/BlueJ-generic-503.jar",
-        "dest-filename": "BlueJ-generic-503.zip",
-        "sha256": "baf54371c9fc75b20cb8b67b76d37c8ebf545a1e243aea5b3422621ce7087fab"
+        "url": "http://www.bluej.org/download/files/BlueJ-generic-510.jar",
+        "dest-filename": "BlueJ-generic-510.zip",
+        "sha256": "c81e6b725e88126ca84d6df65e90299544a87b846b9675e95e76f33e4436f18c"
       }]
     },
     {

--- a/org.bluej.BlueJ.json
+++ b/org.bluej.BlueJ.json
@@ -2,7 +2,7 @@
   "app-id" : "org.bluej.BlueJ",
   "branch" : "stable",
   "runtime" : "org.gnome.Platform",
-  "runtime-version" : "42",
+  "runtime-version" : "44",
   "sdk" : "org.gnome.Sdk",
   "sdk-extensions" : [ "org.freedesktop.Sdk.Extension.openjdk11" ],
   "command": "org.bluej.BlueJ",

--- a/org.bluej.BlueJ.json
+++ b/org.bluej.BlueJ.json
@@ -4,7 +4,7 @@
   "runtime" : "org.gnome.Platform",
   "runtime-version" : "44",
   "sdk" : "org.gnome.Sdk",
-  "sdk-extensions" : [ "org.freedesktop.Sdk.Extension.openjdk11" ],
+  "sdk-extensions" : [ "org.freedesktop.Sdk.Extension.openjdk17" ],
   "command": "org.bluej.BlueJ",
   "finish-args" : [
     "--env=PATH=/app/jre/bin:/usr/bin:/app/bin",
@@ -22,7 +22,7 @@
     {
       "name" : "openjdk",
       "buildsystem" : "simple",
-      "build-commands" : [ "/usr/lib/sdk/openjdk11/install.sh" ]
+      "build-commands" : [ "/usr/lib/sdk/openjdk17/install.sh" ]
     },
     {
       "name": "javafx",

--- a/org.bluej.BlueJ.json
+++ b/org.bluej.BlueJ.json
@@ -30,8 +30,8 @@
       "build-commands": ["mkdir -p /app/javafx", "cp -r ./ /app/javafx"],
       "sources": [{
         "type": "archive",
-        "url": "https://download2.gluonhq.com/openjfx/16/openjfx-16_linux-x64_bin-sdk.zip",
-        "sha256": "5bd4392d0d2d6a4ddc12bedf8d912d4af17f8622f0560dbe0281f56c4f9ed14c"
+        "url": "https://download2.gluonhq.com/openjfx/17/openjfx-17_linux-x64_bin-sdk.zip",
+        "sha256": "9ad44e3d4638393848223b2d885d340009ebd21c6e30f665be96230a9040595b"
       }]
     },
     {


### PR DESCRIPTION
This PR addresses #6, #8, #9 and #11.

It does _not_ solve #5 as of now, as when I try to run a JavaFX application from the [Objects First book](https://www.bluej.org/objects-first/), I get this error:

![Screenshot from 2023-04-28 16-03-09](https://user-images.githubusercontent.com/45298929/235185216-d75f107e-e8b0-448b-afc5-54e476581367.png)

I still thought I'd get this PR done however, if only so that BlueJ itself gets updated, as well as the GNOME runtime and the JDK.