### PR TITLE
Update BlueJ to 5.2.1 and switch to Freedesktop runtime

### DIFF
--- a/bluej
+++ b/bluej
@@ -2,6 +2,6 @@
 APPBASE="/app/bluej"
 JAVAPATH="/app/jre"
 JAVAFX_LIB="/app/javafx/lib"
-CP="$APPBASE/lib/bluej.jar"
-JAVAFX_CP="$JAVAFX_LIB/javafx.base.jar:$JAVAFX_LIB/javafx.controls.jar:$JAVAFX_LIB/javafx.fxml.jar:$JAVAFX_LIB/javafx.graphics.jar:$JAVAFX_LIB/javafx.media.jar:$JAVAFX_LIB/javafx.properties.jar:$JAVAFX_LIB/javafx.swing.jar:$JAVAFX_LIB/javafx.web.jar"
+CP="$APPBASE/lib/boot.jar"
+JAVAFX_CP=$(ls -1 /app/javafx/lib/*.jar | paste -sd ":" -)
 "$JAVAPATH/bin/java" -Djavafx.embed.singleThread=true -Dawt.useSystemAAFontSettings=on -cp "$CP:$JAVAFX_CP" bluej.Boot  "$@"

--- a/org.bluej.BlueJ.appdata.xml
+++ b/org.bluej.BlueJ.appdata.xml
@@ -31,9 +31,6 @@
     <category>Development</category>
     <category>Education</category>
   </categories>
-  <icon type="remote" height="256" width="256">https://web.archive.org/web/20100703075535if_/http://www.bluej.org/bluej-icons/bluej-256.jpg</icon>
-  <icon type="remote" height="128" width="128">https://web.archive.org/web/20150323001255if_/http://www.bluej.org/bluej-icons/bluej-128.jpg</icon>
-  <icon type="remote" height="64" width="64">https://web.archive.org/web/20100703075900if_/http://www.bluej.org/bluej-icons/bluej-64.jpg</icon>
   <kudos>
     <kudo>HiDpiIcon</kudo>
   </kudos>

--- a/org.bluej.BlueJ.appdata.xml
+++ b/org.bluej.BlueJ.appdata.xml
@@ -5,8 +5,13 @@
   <developer_name>King's College London</developer_name>
   <summary>Java IDE for beginners</summary>
   <metadata_license>CC0-1.0</metadata_license>
-  <project_license>GPL-2.0-with-classpath-exception</project_license>
+  <project_license>GPL-2.0-or-later</project_license>
   <url type="homepage">https://bluej.org</url>
+  <url type="bugtracker">https://github.com/k-pet-group/BlueJ-Greenfoot/issues</url>
+  <url type="faq">https://www.bluej.org/faq.html</url>
+  <url type="help">https://www.bluej.org/doc/documentation.html</url>
+  <url type="contact">https://www.bluej.org/support.html</url>
+  <url type="vcs-browser">https://github.com/k-pet-group/BlueJ-Greenfoot</url>
   <description><p>BlueJ is an education-focused interactive Java IDE. It provides a basic debugger and GUI-based method calling.</p></description>
   <screenshots>
     <screenshot type="default">
@@ -26,9 +31,9 @@
     <category>Development</category>
     <category>Education</category>
   </categories>
-  <icon type="remote" height="256" width="256">https://www.bluej.org/bluej-icons/bluej-256.jpg</icon>
-  <icon type="remote" height="128" width="128">https://www.bluej.org/bluej-icons/bluej-128.jpg</icon>
-  <icon type="remote" height="64" width="64">https://www.bluej.org/bluej-icons/bluej-64.jpg</icon>
+  <icon type="remote" height="256" width="256">https://web.archive.org/web/20100703075535if_/http://www.bluej.org/bluej-icons/bluej-256.jpg</icon>
+  <icon type="remote" height="128" width="128">https://web.archive.org/web/20150323001255if_/http://www.bluej.org/bluej-icons/bluej-128.jpg</icon>
+  <icon type="remote" height="64" width="64">https://web.archive.org/web/20100703075900if_/http://www.bluej.org/bluej-icons/bluej-64.jpg</icon>
   <kudos>
     <kudo>HiDpiIcon</kudo>
   </kudos>

--- a/org.bluej.BlueJ.appdata.xml
+++ b/org.bluej.BlueJ.appdata.xml
@@ -33,6 +33,8 @@
     <kudo>HiDpiIcon</kudo>
   </kudos>
   <releases>
+    <release date="2023-10-10" version="5.2.1"/>
+    <release date="2023-06-20" version="5.2.0"/>
     <release date="2022-09-20" version="5.1.0"/>
     <release date="2022-03-28" version="5.0.3"/>
     <release date="2021-08-06" version="5.0.2"/>

--- a/org.bluej.BlueJ.json
+++ b/org.bluej.BlueJ.json
@@ -1,8 +1,8 @@
 {
   "app-id" : "org.bluej.BlueJ",
-  "runtime" : "org.gnome.Platform",
-  "runtime-version" : "44",
-  "sdk" : "org.gnome.Sdk",
+  "runtime" : "org.freedesktop.Platform",
+  "runtime-version" : "23.08",
+  "sdk" : "org.freedesktop.Sdk",
   "sdk-extensions" : [ "org.freedesktop.Sdk.Extension.openjdk17" ],
   "command": "org.bluej.BlueJ",
   "finish-args" : [

--- a/org.bluej.BlueJ.json
+++ b/org.bluej.BlueJ.json
@@ -28,11 +28,20 @@
       "name": "javafx",
       "buildsystem": "simple",
       "build-commands": ["mkdir -p /app/javafx", "cp -r ./ /app/javafx"],
-      "sources": [{
-        "type": "archive",
-        "url": "https://download2.gluonhq.com/openjfx/17/openjfx-17_linux-x64_bin-sdk.zip",
-        "sha256": "9ad44e3d4638393848223b2d885d340009ebd21c6e30f665be96230a9040595b"
-      }]
+      "sources": [
+        {
+          "type": "archive",
+          "only-arches": ["x86_64"],
+          "url": "https://download2.gluonhq.com/openjfx/17/openjfx-17_linux-x64_bin-sdk.zip",
+          "sha256": "9ad44e3d4638393848223b2d885d340009ebd21c6e30f665be96230a9040595b"
+        },
+        {
+          "type": "archive",
+          "only-arches": ["aarch64"],
+          "url": "https://download2.gluonhq.com/openjfx/17/openjfx-17_linux-aarch64_bin-sdk.zip",
+          "sha256": "e0cdd4f4d9219b38c16e239d119553b6b5b69c0aae9551255e19c1022d6a3e29"
+        }
+      ]
     },
     {
       "name": "bluej",

--- a/org.bluej.BlueJ.json
+++ b/org.bluej.BlueJ.json
@@ -1,6 +1,5 @@
 {
   "app-id" : "org.bluej.BlueJ",
-  "branch" : "stable",
   "runtime" : "org.gnome.Platform",
   "runtime-version" : "44",
   "sdk" : "org.gnome.Sdk",

--- a/org.bluej.BlueJ.json
+++ b/org.bluej.BlueJ.json
@@ -10,7 +10,6 @@
     "--share=network",
     "--socket=x11",
     "--share=ipc",
-    "--socket=wayland",
     "--device=dri",
     "--socket=pulseaudio",
     "--filesystem=host",

--- a/org.bluej.BlueJ.json
+++ b/org.bluej.BlueJ.json
@@ -45,9 +45,9 @@
       ],
       "sources": [{
         "type": "archive",
-        "url": "http://www.bluej.org/download/files/BlueJ-generic-510.jar",
-        "dest-filename": "BlueJ-generic-510.zip",
-        "sha256": "c81e6b725e88126ca84d6df65e90299544a87b846b9675e95e76f33e4436f18c"
+        "url": "https://www.bluej.org/download/files/BlueJ-generic-521.jar",
+        "dest-filename": "BlueJ-generic-521.zip",
+        "sha256": "d8c9e503f72f2347cfa9b5e07f33c21e2c35d0674a5892101c132b3314120f38"
       }]
     },
     {

--- a/org.bluej.BlueJ.json
+++ b/org.bluej.BlueJ.json
@@ -14,8 +14,7 @@
     "--device=dri",
     "--socket=pulseaudio",
     "--filesystem=host",
-    "--filesystem=xdg-run/dconf", "--filesystem=~/.config/dconf:ro",
-    "--talk-name=ca.desrt.dconf", "--env=DCONF_USER_CONFIG_DIR=.config/dconf"
+    "--metadata=X-DConf=migrate-path=/org/bluej/BlueJ/"
   ],
   "modules" : [
     {


### PR DESCRIPTION
Closes https://github.com/flathub/org.bluej.BlueJ/pull/14
Closes https://github.com/flathub/org.bluej.BlueJ/pull/7

Combines work from above two PRs

Closes https://github.com/flathub/org.bluej.BlueJ/issues/11
Closes https://github.com/flathub/org.bluej.BlueJ/issues/8

See https://github.com/flathub/flathub/issues/1040 for the dconf migration