### PR TITLE
Edit description in appdata.xml denoting Classpath Exception

### DIFF
--- a/org.bluej.BlueJ.appdata.xml
+++ b/org.bluej.BlueJ.appdata.xml
@@ -12,7 +12,7 @@
   <url type="help">https://www.bluej.org/doc/documentation.html</url>
   <url type="contact">https://www.bluej.org/support.html</url>
   <url type="vcs-browser">https://github.com/k-pet-group/BlueJ-Greenfoot</url>
-  <description><p>BlueJ is an education-focused interactive Java IDE. It provides a basic debugger and GUI-based method calling.</p></description>
+  <description><p>BlueJ is an education-focused interactive Java IDE. It provides a basic debugger and GUI-based method calling. It is licensed under the GPL 2.0 with the Classpath Exception.</p></description>
   <screenshots>
     <screenshot type="default">
       <caption>Editor Window</caption>


### PR DESCRIPTION
For more licensing clarification.

Can be safely removed when https://github.com/flathub/org.flatpak.Builder/issues/187 gets resolved, especially since [the "WITH" operator that the license expression best suited to BlueJ needs (`GPL-2.0-or-later WITH Classpath-exception-2.0`) is not supported in flatpak-builder's appstream-util as of now](https://github.com/flathub/org.flatpak.Builder/issues/187#issuecomment-1837302017).